### PR TITLE
Fix empty gap on right of screen

### DIFF
--- a/agdk/game_controller/app/src/main/cpp/demo_scene.cpp
+++ b/agdk/game_controller/app/src/main/cpp/demo_scene.cpp
@@ -278,7 +278,7 @@ void DemoScene::SetupUIWindow() {
     ImGuiIO &io = ImGui::GetIO();
     const float windowStartY = NativeEngine::GetInstance()->GetSystemBarOffset();
     ImVec2 windowPosition(0.0f, windowStartY);
-    ImVec2 minWindowSize(io.DisplaySize.x * 0.95f, io.DisplaySize.y);
+    ImVec2 minWindowSize(io.DisplaySize.x, io.DisplaySize.y);
     ImVec2 maxWindowSize = io.DisplaySize;
     ImGui::SetNextWindowPos(windowPosition);
     ImGui::SetNextWindowSizeConstraints(minWindowSize, maxWindowSize, NULL, NULL);


### PR DESCRIPTION
Fixes the bug:

"Hi,
i use the AGDK with the game controller example code successfully. As you know, the example is based on ImGui.
In this context I see the following incorrect behavior: The entire display size is not used.

Repo with the game controller example:
https://github.com/natetrost/games-samples/tree/main/agdk/game_controller

The current ImGui version (1.90.4) is used:
https://github.com/ocornut/imgui

In the method NativeEngine::PrepareToRender(), the display size is still correctly passed to the ImGui manager:
--> File native_engine.cpp, line 546
      // Keep the ImGui display size up to date
          mImGuiManager -> SetDisplaySize(mSurfWidth, mSurfHeight, mScreenDensity);

For a Samsung Tab S7, for example, 1600x2560 pixels.

However, this area is not used, but a space of around 150 pixels is always left free on the right edge of the screen (see screenshot).
This behavior is observed on many devices and in the Android Studio Emulator.
The behavior affects at least Android versions 11-14."

![Screenshot_20240409](https://github.com/user-attachments/assets/ae0281d9-d763-4c88-afe2-6552d33ba177)


